### PR TITLE
 Improve: install target for MLton

### DIFF
--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -1,6 +1,9 @@
 
 MLTON       := mlton
 MLTON_FLAGS := -default-ann "nonexhaustiveMatch ignore"
+ifneq ($(MLB_PATH_MAP),)
+MLTON_FLAGS += -mlb-path-map $(MLB_PATH_MAP)
+endif
 
 MLLEX       := mllex
 MLYACC      := mlyacc

--- a/Makefile.mlton
+++ b/Makefile.mlton
@@ -91,10 +91,21 @@ endif
 
 
 .PHONY: install
-install:
-	install -D -m 0755 -t $(PREFIX)/bin                      $(SMLFORMAT)
-	install -D -m 0644 -t $(PREFIX)/formatlib                smlformatlib.mlb
-	install -D -m 0644 -t $(PREFIX)/formatlib/formatlib/main formatlib/main/*
+install: typecheck_smlformatlib $(SMLFORMAT) $(SMLFORMATLIB_MLB)
+	@[ -e $(PREFIX)/lib/SMLFormat ] || mkdir $(PREFIX)/lib/SMLFormat
+	@$(MLTON) $(MLTON_FLAGS) -stop f $(SMLFORMATLIB_MLB) | \
+	while read file; do \
+		if expr $$(readlink -f $$file) : ^$$(pwd) >/dev/null; then \
+			cp --parents $$(realpath --relative-to=$$(pwd) $$file) $(PREFIX)/lib/SMLFormat; \
+			echo -n . ; \
+		fi; \
+	done
+	@install -D -m 0755 -t $(PREFIX)/bin $(SMLFORMAT)
+	@echo "Installation has been completed."
+	@echo "Please add the entry to your mlb path map file:"
+	@echo ""
+	@echo "  SMLFORMAT_LIB $(PREFIX)/lib/SMLFormat"
+	@echo ""
 
 
 .PHONY: clean

--- a/Readme.md
+++ b/Readme.md
@@ -185,10 +185,12 @@ $ echo 'SMLFORMAT_LIB /path/to/smlformatlib.mlb' >> $MLTON_ROOT/mlb-path-map
 
 ### Test
 
-Perform unit test for `formatlib`, specify `test` target:
+To perform unit test for `formatlib`, execute `test` target.
+This Unit test requires [SMLUnit], you need to specify the path to the library.
+
 
 ```sh
-$ make -f Makefile.mlton test
+$ make -f Makefile.mlton MLB_PATH_MAP=/path/to/mlb-path-map test
 Makefile.mlton:83: smlformatlib.mlb.d: No such file or directory
 Makefile.mlton:83: generator/mlton/smlformat.mlb.d: No such file or directory
 .

--- a/Readme.md
+++ b/Readme.md
@@ -179,7 +179,28 @@ Install by `install` target.
 
 ```sh
 $ make -f Makefile.mlton install
-$ echo 'SMLFORMAT_LIB /path/to/smlformatlib.mlb' >> $MLTON_ROOT/mlb-path-map
+  [MLTON] typecheck smlformatlib.mlb
+................Installation has been completed.
+Please add the entry to your mlb path map file:
+
+  SMLFORMAT_LIB /usr/local/mlton/lib/SMLFormat
+
+```
+
+It is able to change the location with `PREFIX` variable like:
+
+```sh
+make -f Makefile.mlton PREFIX=~/.sml/mlton install
+.
+.
+  SMLFORMAT_LIB /home/user/.sml/mlton/lib/SMLFormat
+
+```
+
+After `make install`, you need to add an entry in your mlb path mapping file:
+
+```sh
+$ echo 'SMLFORMAT_LIB /path/to/$PREFIX/lib/SMLFormat' >> /path/to/mlb-path-map
 ```
 
 
@@ -224,4 +245,6 @@ YAMATODANI Kiyoshi @2010, Tohoku University.
 
 
 [SMLFormat]: https://www.pllab.riec.tohoku.ac.jp/smlsharp/ja/?cmd=view&p=SMLFormat&key=SMLFormat "SMLFormat"
+[SMLUnit]: http://www.pllab.riec.tohoku.ac.jp/smlsharp/?SMLUnit "SMLUnit"
+
 


### PR DESCRIPTION
# Improvements
- `install` target copy whole library files.
- `test` target description requires path to `SMLUNIT` explicitly
